### PR TITLE
Scaffold platform architecture with tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "work"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Backend lint
+        run: python -m compileall backend/app
+
+      - name: Backend tests
+        run: python -m unittest discover backend/tests
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Frontend install
+        working-directory: frontend
+        run: npm install
+
+      - name: Frontend lint
+        working-directory: frontend
+        run: npm run lint
+
+      - name: Frontend tests
+        working-directory: frontend
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.env
+.env.*
+node_modules/
+*.log
+.DS_Store
+/dist/
+/tmp/
+/.venv/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# GPT5 Codex AI Subscription Platform
+
+This repository hosts the scaffold for an AI-driven subscription platform. It is organised as a monorepo with dedicated areas for the frontend experience, backend services, infrastructure tooling, and continuous integration.
+
+## Repository Layout
+
+- `frontend/` – Vanilla JavaScript frontend assets, local development scripts, and automated tests.
+- `backend/` – Python-based HTTP service exposing the AI ideation API together with accompanying unit tests.
+- `infra/` – Infrastructure assets, such as container orchestration and database bootstrap files.
+- `.github/workflows/` – GitHub Actions workflows that lint and test the codebase on every push and pull request.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 18 or later.
+- Python 3.11 or later.
+
+### Frontend
+
+```bash
+cd frontend
+npm install   # installs development dependencies (none by default, but creates a lockfile)
+npm run dev   # start the static development server
+npm run lint  # run lightweight syntax checks
+npm test      # execute Node.js test suites
+```
+
+The frontend delivers a simple landing page that highlights the creative AI experiences offered by the platform. Utility modules drive the ideation content and are fully covered by unit tests.
+
+### Backend
+
+```bash
+cd backend
+python -m compileall app  # quick syntax validation
+python -m unittest discover tests
+python app/server.py      # start the HTTP API on http://127.0.0.1:8000
+```
+
+The backend exposes a `/api/ideas` endpoint that returns deterministic AI concept pitches based on incoming themes and tones. Logic is encapsulated within `app.ai` so it can be reused by additional services or asynchronous workers.
+
+### Infrastructure
+
+`infra/docker-compose.yml` provisions a local environment composed of the backend API, a static frontend server, and a PostgreSQL database seed. These services are placeholders intended to be replaced by production-ready deployments during later project phases.
+
+## Continuous Integration
+
+GitHub Actions automatically run the Python and Node.js lint/test suites defined above. The workflow is located at `.github/workflows/ci.yml` and is executed for pull requests and pushes to the default branch to maintain high code quality.
+
+## Next Steps
+
+1. Replace the handcrafted HTTP server with a production-ready framework such as FastAPI or NestJS once external dependencies can be installed.
+2. Connect the backend to a persistent PostgreSQL instance using a migration tool (e.g., Alembic or Prisma).
+3. Expand the frontend into a fully fledged application using a component framework like Next.js or Remix.
+4. Enrich the AI module with real model integrations and add automated contract tests that validate the prompt/response workflow end-to-end.
+

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY app ./app
+
+EXPOSE 8000
+CMD ["python", "app/server.py"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,22 @@
+# Backend Service
+
+This directory contains a pure-Python HTTP service that powers the GPT5 Codex AI subscription platform. The service exposes a single endpoint, `/api/ideas`, which turns request payloads into deterministic AI subscription concepts.
+
+## Running Locally
+
+```bash
+python app/server.py
+```
+
+The server listens on `http://127.0.0.1:8000` by default. POST requests to `/api/ideas` should include JSON with a `seed` (or `theme`) and optional `tone` field.
+
+## Testing
+
+```bash
+python -m compileall app
+python -m unittest discover tests
+```
+
+## Configuration
+
+Copy `.env.example` to `.env` and populate connection strings when the service is extended with persistent storage or third-party integrations.

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend top-level package."""

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+"""Backend application package for the GPT5 Codex platform."""

--- a/backend/app/ai.py
+++ b/backend/app/ai.py
@@ -1,0 +1,96 @@
+"""Deterministic AI ideation helpers used by the backend service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Dict
+
+
+@dataclass
+class Idea:
+    """Represents a single creative concept returned by the AI module."""
+
+    title: str
+    description: str
+    subscription_prompt: str
+
+    def as_payload(self) -> Dict[str, str]:
+        """Return a serialisable representation."""
+
+        return {
+            "title": self.title,
+            "description": self.description,
+            "subscriptionPrompt": self.subscription_prompt,
+        }
+
+
+class IdeaGenerator:
+    """Create deterministic ideas derived from user-provided seeds."""
+
+    _tones = (
+        {
+            "name": "Immersive Script Lab",
+            "flavour": "cinematic story weaving",
+            "upsell": "story branches, audio casts, and episodic drops",
+        },
+        {
+            "name": "Daily AI Duel",
+            "flavour": "rapid-fire creative battles",
+            "upsell": "competitive leaderboards and mentor critiques",
+        },
+        {
+            "name": "Co-Creation Hub",
+            "flavour": "collaborative ideation rituals",
+            "upsell": "team workspaces and executive summaries",
+        },
+    )
+
+    def _hash_seed(self, seed: str) -> int:
+        digest = sha256(seed.encode("utf-8")).hexdigest()
+        return int(digest, 16)
+
+    def generate(self, seed: str, tone_preference: str | None = None) -> Idea:
+        """Return a deterministic :class:`Idea` from the supplied seed."""
+
+        if not seed or not isinstance(seed, str):
+            raise TypeError("Seed must be a non-empty string")
+
+        normalised = " ".join(seed.strip().split())
+        fingerprint = self._hash_seed(normalised)
+        tone_index = fingerprint % len(self._tones)
+
+        if tone_preference:
+            lowered = tone_preference.lower()
+            for index, tone in enumerate(self._tones):
+                if lowered in tone["name"].lower():
+                    tone_index = index
+                    break
+
+        tone = self._tones[tone_index]
+        headline = normalised.title()
+
+        description = (
+            f"An AI concierge that channels {tone['flavour']} to elevate your "
+            f"\"{normalised}\" concept into a binge-worthy experience."
+        )
+        subscription_prompt = (
+            "Subscribe to unlock "
+            f"{tone['upsell']} tailored to your {headline} ambitions."
+        )
+
+        return Idea(
+            title=f"{headline} Accelerator",
+            description=description,
+            subscription_prompt=subscription_prompt,
+        )
+
+
+DEFAULT_GENERATOR = IdeaGenerator()
+
+
+def generate_subscription_idea(seed: str, tone: str | None = None) -> Dict[str, str]:
+    """Public helper for modules that require JSON serialisable data."""
+
+    idea = DEFAULT_GENERATOR.generate(seed=seed, tone_preference=tone)
+    return idea.as_payload()

--- a/backend/app/server.py
+++ b/backend/app/server.py
@@ -1,0 +1,78 @@
+"""Minimal HTTP server exposing AI ideation endpoints."""
+
+from __future__ import annotations
+
+import json
+import logging
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Tuple
+
+from .ai import generate_subscription_idea
+
+LOGGER = logging.getLogger("gpt5_codex.server")
+
+
+class AIRequestHandler(BaseHTTPRequestHandler):
+    """Handle HTTP requests for the AI ideation API."""
+
+    server_version = "GPT5Codex/0.1"
+
+    def log_message(self, format: str, *args) -> None:  # noqa: D401 - inherited signature
+        """Route log messages through :mod:`logging` instead of stderr."""
+
+        LOGGER.info("%s - - %s", self.client_address[0], format % args)
+
+    def do_POST(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+        if self.path != "/api/ideas":
+            self.send_error(HTTPStatus.NOT_FOUND, "Endpoint not found")
+            return
+
+        content_length = int(self.headers.get("Content-Length", "0"))
+        try:
+            payload = self.rfile.read(content_length) if content_length > 0 else b"{}"
+            data = json.loads(payload.decode("utf-8"))
+        except json.JSONDecodeError:
+            self.send_error(HTTPStatus.BAD_REQUEST, "Invalid JSON payload")
+            return
+
+        seed = data.get("seed") or data.get("theme")
+        tone = data.get("tone")
+
+        try:
+            idea = generate_subscription_idea(seed, tone)
+        except TypeError as error:
+            self.send_error(HTTPStatus.BAD_REQUEST, str(error))
+            return
+
+        response = json.dumps(idea).encode("utf-8")
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
+
+
+def create_server(address: Tuple[str, int] | None = None) -> ThreadingHTTPServer:
+    """Create a configured HTTP server instance."""
+
+    host, port = address or ("127.0.0.1", 8000)
+    server = ThreadingHTTPServer((host, port), AIRequestHandler)
+    LOGGER.info("Starting AI server on http://%s:%s", host, server.server_port)
+    return server
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    server = create_server()
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        LOGGER.info("Shutting down server")
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_ai.py
+++ b/backend/tests/test_ai.py
@@ -1,0 +1,27 @@
+"""Unit tests for the deterministic AI idea generator."""
+
+import unittest
+
+from backend.app.ai import IdeaGenerator, generate_subscription_idea
+
+
+class IdeaGeneratorTests(unittest.TestCase):
+    def test_generate_subscription_idea_returns_expected_keys(self) -> None:
+        payload = generate_subscription_idea("Solar Arcade")
+        self.assertEqual(set(payload.keys()), {"title", "description", "subscriptionPrompt"})
+
+    def test_generator_is_deterministic_for_same_seed(self) -> None:
+        generator = IdeaGenerator()
+        first = generator.generate("Metaverse Retreat")
+        second = generator.generate("Metaverse Retreat")
+        self.assertEqual(first.title, second.title)
+        self.assertEqual(first.description, second.description)
+
+    def test_generator_respects_tone_hint(self) -> None:
+        generator = IdeaGenerator()
+        idea = generator.generate("Neuro Garden", tone_preference="Co-Creation")
+        self.assertIn("collaborative", idea.description.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_server.py
+++ b/backend/tests/test_server.py
@@ -1,0 +1,60 @@
+"""Integration-style tests for the handcrafted HTTP server."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import unittest
+import urllib.error
+import urllib.request
+from typing import Tuple
+
+from backend.app.server import create_server
+
+
+class _ServerContext:
+    def __init__(self) -> None:
+        self.server = create_server(("127.0.0.1", 0))
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def __enter__(self) -> Tuple[str, int]:
+        self.thread.start()
+        time.sleep(0.1)
+        return self.server.server_address
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.server.shutdown()
+        self.thread.join(timeout=1)
+        self.server.server_close()
+
+
+class ServerTests(unittest.TestCase):
+    def test_post_ideas_returns_payload(self) -> None:
+        with _ServerContext() as (host, port):
+            request = urllib.request.Request(
+                url=f"http://{host}:{port}/api/ideas",
+                data=json.dumps({"seed": "Ocean Retreat"}).encode("utf-8"),
+                method="POST",
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(request, timeout=2) as response:
+                self.assertEqual(response.status, 200)
+                body = json.loads(response.read().decode("utf-8"))
+                self.assertTrue(body["title"].endswith("Accelerator"))
+
+    def test_post_invalid_path_returns_not_found(self) -> None:
+        with _ServerContext() as (host, port):
+            request = urllib.request.Request(
+                url=f"http://{host}:{port}/not-found",
+                data=b"{}",
+                method="POST",
+                headers={"Content-Type": "application/json"},
+            )
+            with self.assertRaises(urllib.error.HTTPError) as ctx:
+                urllib.request.urlopen(request, timeout=2)
+            self.assertEqual(ctx.exception.code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine
+
+WORKDIR /usr/src/app
+COPY package.json ./
+COPY src ./src
+COPY public ./public
+COPY scripts ./scripts
+
+ENV HOST=0.0.0.0
+EXPOSE 3000
+CMD ["node", "scripts/dev-server.mjs"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,13 @@
+# Frontend Shell
+
+The frontend provides a static marketing experience for the GPT5 Codex platform. It highlights the signature AI features and allows visitors to generate teaser concepts using a deterministic client-side module.
+
+## Available Scripts
+
+```bash
+npm run dev   # start a lightweight static server at http://127.0.0.1:3000
+npm run lint  # syntax-check JavaScript sources using the Node.js parser
+npm test      # execute automated tests with the built-in node:test runner
+```
+
+The project intentionally avoids third-party dependencies so it can run in restricted environments. When the platform is ready to evolve, replace the static setup with your framework of choice (Next.js, Remix, Astro, etc.) and hook it into the backend API.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,15 @@
+{
+  "name": "gpt5-codex-frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gpt5-codex-frontend",
+      "version": "0.1.0",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "gpt5-codex-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Static frontend shell for the GPT5 Codex AI subscription platform.",
+  "scripts": {
+    "dev": "node scripts/dev-server.mjs",
+    "lint": "node scripts/lint.mjs",
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GPT5 Codex – AI Subscription Playground</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <div class="hero__content">
+        <h1>Invent the future with GPT5 Codex</h1>
+        <p>
+          Explore immersive AI story experiences, collaborative creation rooms, and personalised challenge tracks that inspire paid
+          subscribers to stay curious.
+        </p>
+        <button id="cta-button" class="hero__cta">Start Your Creative Trial</button>
+      </div>
+    </header>
+
+    <main>
+      <section class="ideas">
+        <h2>Signature AI Experiences</h2>
+        <div id="idea-list" class="ideas__list" aria-live="polite"></div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>Crafted by the GPT5 Codex specialist team – business, product, engineering, security, and operations in harmony.</p>
+    </footer>
+
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/frontend/public/styles.css
+++ b/frontend/public/styles.css
@@ -1,0 +1,88 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #0f172a;
+  color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.hero {
+  padding: 4rem 1.5rem;
+  background: radial-gradient(circle at top left, #38bdf8, #0f172a 60%);
+  text-align: center;
+}
+
+.hero__content {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.hero__cta {
+  margin-top: 1.5rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  border: none;
+  background: linear-gradient(135deg, #22d3ee, #0ea5e9);
+  color: #0f172a;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.hero__cta:hover,
+.hero__cta:focus {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(34, 211, 238, 0.2);
+}
+
+main {
+  flex: 1;
+  padding: 3rem 1.5rem;
+  background: #020617;
+}
+
+.ideas {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.ideas__list {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin-top: 2rem;
+}
+
+.idea-card {
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 16px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.idea-card h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.idea-card p {
+  margin: 0;
+  line-height: 1.6;
+  color: #cbd5f5;
+}
+
+.footer {
+  padding: 1.5rem;
+  text-align: center;
+  font-size: 0.875rem;
+  background: #0b1120;
+  color: #94a3b8;
+}

--- a/frontend/scripts/dev-server.mjs
+++ b/frontend/scripts/dev-server.mjs
@@ -1,0 +1,77 @@
+import { createServer } from 'http';
+import { readFile } from 'fs/promises';
+import { createReadStream, statSync, existsSync } from 'fs';
+import { extname, join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const rootDir = join(__dirname, '..');
+const publicDir = join(rootDir, 'public');
+const srcDir = join(rootDir, 'src');
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.svg': 'image/svg+xml'
+};
+
+function resolveFile(urlPath) {
+  if (urlPath === '/' || urlPath === '') {
+    return join(publicDir, 'index.html');
+  }
+
+  const directPublic = join(publicDir, urlPath);
+  if (existsSync(directPublic) && statSync(directPublic).isFile()) {
+    return directPublic;
+  }
+
+  const directSrc = join(srcDir, urlPath.replace(/^\//, ''));
+  if (existsSync(directSrc) && statSync(directSrc).isFile()) {
+    return directSrc;
+  }
+
+  return null;
+}
+
+async function requestHandler(req, res) {
+  const filePath = resolveFile(req.url ?? '/');
+
+  if (!filePath) {
+    res.statusCode = 404;
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+    res.end('Not Found');
+    return;
+  }
+
+  const ext = extname(filePath).toLowerCase();
+  const contentType = MIME_TYPES[ext] ?? 'application/octet-stream';
+  res.statusCode = 200;
+  res.setHeader('Content-Type', contentType);
+
+  if (ext === '.html') {
+    const content = await readFile(filePath, 'utf8');
+    res.end(content);
+    return;
+  }
+
+  createReadStream(filePath).pipe(res);
+}
+
+const port = Number(process.env.PORT || 3000);
+const host = process.env.HOST || '127.0.0.1';
+
+createServer((req, res) => {
+  requestHandler(req, res).catch((error) => {
+    console.error('Error while serving request:', error);
+    res.statusCode = 500;
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+    res.end('Internal Server Error');
+  });
+}).listen(port, host, () => {
+  console.log(`Development server running at http://${host}:${port}`);
+});

--- a/frontend/scripts/lint.mjs
+++ b/frontend/scripts/lint.mjs
@@ -1,0 +1,57 @@
+import { readdirSync } from 'fs';
+import { join, extname, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { spawnSync } from 'child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = join(__dirname, '..');
+
+const TARGET_FOLDERS = ['src', 'scripts', 'tests'];
+const SUPPORTED_EXTENSIONS = new Set(['.js', '.mjs']);
+
+function collectFiles(relativeFolder) {
+  const absoluteFolder = join(projectRoot, relativeFolder);
+  const entries = readdirSync(absoluteFolder, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const nextRelativePath = join(relativeFolder, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(nextRelativePath));
+    } else {
+      const ext = extname(entry.name).toLowerCase();
+      if (SUPPORTED_EXTENSIONS.has(ext)) {
+        files.push(join(projectRoot, nextRelativePath));
+      }
+    }
+  }
+
+  return files;
+}
+
+let failures = 0;
+
+for (const folder of TARGET_FOLDERS) {
+  try {
+    const files = collectFiles(folder);
+    for (const file of files) {
+      const result = spawnSync('node', ['--check', file], { stdio: 'inherit' });
+      if (result.status !== 0) {
+        failures += 1;
+      }
+    }
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      continue;
+    }
+    throw error;
+  }
+}
+
+if (failures > 0) {
+  console.error(`Linting failed for ${failures} file(s).`);
+  process.exit(1);
+}
+
+console.log('All JavaScript files passed syntax checks.');

--- a/frontend/src/aiIdeas.js
+++ b/frontend/src/aiIdeas.js
@@ -1,0 +1,51 @@
+const SIGNATURE_EXPERIENCES = [
+  {
+    id: 'immersive-script-lab',
+    title: 'Immersive Script Lab',
+    description:
+      'Transform any character brief into a multi-branch cinematic script. Export storyboards, table reads, and voiceovers in seconds.',
+    subscriptionPrompt: 'Unlock director mode to publish weekly mini-series and earn from fan subscriptions.'
+  },
+  {
+    id: 'daily-ai-duel',
+    title: 'Daily AI Duel',
+    description:
+      'Compete in time-boxed creative battles. Pitch products, slogans, or growth hacks while the AI coach scores every move.',
+    subscriptionPrompt: 'Upgrade to challenge industry mentors and unlock trend analytics dashboards.'
+  },
+  {
+    id: 'co-creation-hub',
+    title: 'Co-Creation Hub',
+    description:
+      'Collaborate live with your team inside a shared AI canvas. Branch ideas, annotate insights, and merge the best concepts.',
+    subscriptionPrompt: 'Pro members schedule branded co-creation lounges and automate recap summaries.'
+  }
+];
+
+export function listSignatureExperiences() {
+  return SIGNATURE_EXPERIENCES.map((experience) => ({ ...experience }));
+}
+
+export function craftIdeaFromSeed(seed) {
+  if (!seed || typeof seed !== 'string') {
+    throw new TypeError('Seed must be a non-empty string');
+  }
+
+  const normalised = seed.trim().toLowerCase();
+  const base = normalised.replace(/[^a-z0-9]+/g, ' ').trim();
+  const headline = base
+    .split(' ')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+
+  const toneIndex = (normalised.length + normalised.charCodeAt(0)) % SIGNATURE_EXPERIENCES.length;
+  const tone = SIGNATURE_EXPERIENCES[toneIndex];
+
+  return {
+    id: `${tone.id}-${normalised.replace(/\s+/g, '-')}`,
+    title: `${headline} Accelerator`,
+    description: `An adaptive AI lane that blends ${tone.title.toLowerCase()} energy with your "${seed}" vision.`,
+    subscriptionPrompt: `Subscribe to unlock ${tone.subscriptionPrompt.toLowerCase()}`
+  };
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,64 @@
+import { listSignatureExperiences, craftIdeaFromSeed } from './aiIdeas.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const ideaList = document.getElementById('idea-list');
+  const ctaButton = document.getElementById('cta-button');
+
+  if (ideaList) {
+    const experiences = listSignatureExperiences();
+    for (const experience of experiences) {
+      const card = document.createElement('article');
+      card.className = 'idea-card';
+
+      const title = document.createElement('h3');
+      title.textContent = experience.title;
+
+      const description = document.createElement('p');
+      description.textContent = experience.description;
+
+      const prompt = document.createElement('p');
+      prompt.textContent = experience.subscriptionPrompt;
+      prompt.setAttribute('data-role', 'subscription-prompt');
+
+      card.appendChild(title);
+      card.appendChild(description);
+      card.appendChild(prompt);
+      ideaList.appendChild(card);
+    }
+  }
+
+  if (ctaButton) {
+    ctaButton.addEventListener('click', () => {
+      const seed = window.prompt('What creative dream should we accelerate?');
+      if (!seed) {
+        return;
+      }
+
+      try {
+        const idea = craftIdeaFromSeed(seed);
+        const highlight = document.createElement('article');
+        highlight.className = 'idea-card';
+        highlight.setAttribute('data-role', 'generated-idea');
+
+        const heading = document.createElement('h3');
+        heading.textContent = idea.title;
+
+        const description = document.createElement('p');
+        description.textContent = idea.description;
+
+        const prompt = document.createElement('p');
+        prompt.textContent = idea.subscriptionPrompt;
+
+        highlight.appendChild(heading);
+        highlight.appendChild(description);
+        highlight.appendChild(prompt);
+
+        if (ideaList) {
+          ideaList.prepend(highlight);
+        }
+      } catch (error) {
+        window.alert(error.message);
+      }
+    });
+  }
+});

--- a/frontend/tests/idea-generator.test.js
+++ b/frontend/tests/idea-generator.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { craftIdeaFromSeed, listSignatureExperiences } from '../src/aiIdeas.js';
+
+test('listSignatureExperiences returns immutable copies', () => {
+  const experiences = listSignatureExperiences();
+  assert.equal(experiences.length, 3);
+  experiences[0].title = 'mutated';
+
+  const fresh = listSignatureExperiences();
+  assert.notEqual(fresh[0].title, 'mutated');
+});
+
+test('craftIdeaFromSeed enforces a non-empty string input', () => {
+  assert.throws(() => craftIdeaFromSeed(''), /Seed must be a non-empty string/);
+  assert.throws(() => craftIdeaFromSeed(), /Seed must be a non-empty string/);
+});
+
+test('craftIdeaFromSeed produces deterministic identifiers', () => {
+  const first = craftIdeaFromSeed('Galactic Tea Bar');
+  const second = craftIdeaFromSeed('galactic tea bar');
+  assert.equal(first.id, second.id);
+  assert.match(first.title, /Galactic Tea Bar/);
+});
+
+test('craftIdeaFromSeed blends tone specific messaging', () => {
+  const idea = craftIdeaFromSeed('Quantum Fitness Studio');
+  assert.ok(idea.description.includes('quantum fitness studio'.replace(/\s+/g, ' ')) === false, 'description is humanised');
+  assert.ok(idea.subscriptionPrompt.startsWith('Subscribe to unlock'));
+});

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.9'
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: gpt5_codex
+      POSTGRES_PASSWORD: development
+      POSTGRES_DB: gpt5_codex
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  backend:
+    build:
+      context: ../backend
+      dockerfile: ../backend/Dockerfile
+    environment:
+      DATABASE_URL: postgresql://gpt5_codex:development@postgres:5432/gpt5_codex
+    depends_on:
+      - postgres
+    ports:
+      - "8000:8000"
+
+  frontend:
+    build:
+      context: ../frontend
+      dockerfile: ../frontend/Dockerfile
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- add monorepo documentation and ignore rules describing the AI subscription platform scaffold
- implement deterministic AI ideation frontend utilities with a static landing page, custom dev server, and node:test coverage
- build a pure-Python HTTP API for idea generation, integration tests, Docker assets, infrastructure stubs, and a CI workflow running lint and tests

## Testing
- python -m compileall backend/app
- python -m unittest discover backend/tests
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d11e1171d08326b1b69f7086abdbae