### PR TITLE
Fix dev server src path resolution

### DIFF
--- a/frontend/scripts/dev-server.mjs
+++ b/frontend/scripts/dev-server.mjs
@@ -30,7 +30,10 @@ function resolveFile(urlPath) {
     return directPublic;
   }
 
-  const directSrc = join(srcDir, urlPath.replace(/^\//, ''));
+  const srcRelativePath = urlPath
+    .replace(/^\/?src\//, '')
+    .replace(/^\//, '');
+  const directSrc = join(srcDir, srcRelativePath);
   if (existsSync(directSrc) && statSync(directSrc).isFile()) {
     return directSrc;
   }


### PR DESCRIPTION
## Summary
- strip the `/src/` prefix from module requests before joining with the source directory so module imports resolve correctly

## Testing
- npm run dev
- curl -i http://127.0.0.1:3000/src/main.js
- curl -I http://127.0.0.1:3000/src/aiIdeas.js

------
https://chatgpt.com/codex/tasks/task_e_68d13792930c83269e690199f78a5b86