### PR TITLE
Handle case-insensitive attachment deduplication

### DIFF
--- a/backend/app/ai.py
+++ b/backend/app/ai.py
@@ -580,15 +580,17 @@ class HardwarePlanGenerator:
         if not isinstance(attachments, Iterable) or isinstance(attachments, (str, bytes)):
             raise TypeError("Attachments must be an iterable of strings")
 
-        cleaned: List[str] = []
+        deduped: Dict[str, str] = {}
         for attachment in attachments:
             if not isinstance(attachment, str):
                 raise TypeError("Attachments must be an iterable of strings")
-            normalised = " ".join(attachment.strip().split())
-            if normalised:
-                cleaned.append(normalised)
+            original = " ".join(attachment.strip().split())
+            if not original:
+                continue
+            key = self._normalise(original)
+            deduped.setdefault(key, original)
 
-        unique_sorted = sorted(dict.fromkeys(cleaned), key=str.lower)
+        unique_sorted = [deduped[key] for key in sorted(deduped, key=str)]
         return unique_sorted
 
     def _craft_differentiator(

--- a/backend/tests/test_ai.py
+++ b/backend/tests/test_ai.py
@@ -30,6 +30,11 @@ class HardwarePlanGeneratorTests(unittest.TestCase):
         self.assertEqual(first.device_key, second.device_key)
         self.assertEqual(first.differentiator, second.differentiator)
 
+    def test_generator_deduplicates_case_variant_attachments(self) -> None:
+        generator = HardwarePlanGenerator()
+        plan = generator.generate("iot setup", attachments=["Sensor", "sensor"])
+        self.assertEqual(plan.attachments, ["Sensor"])
+
     def test_generator_resolves_aliases(self) -> None:
         generator = HardwarePlanGenerator()
         plan = generator.generate("電鍋")


### PR DESCRIPTION
## Summary
- ensure hardware attachment preparation deduplicates entries by case while preserving the first formatting provided
- add a regression test covering case-insensitive attachment deduplication in the hardware plan generator

## Testing
- python -m compileall backend/app
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68d156b17d0883268cfabfb586460d6f