### PR TITLE
Preserve attachment casing during deduplication

### DIFF
--- a/frontend/src/aiIdeas.js
+++ b/frontend/src/aiIdeas.js
@@ -154,8 +154,15 @@ function prepareAttachments(attachments = []) {
     .map((item) => item.trim())
     .filter(Boolean);
 
-  const deduped = Array.from(new Set(cleaned.map((item) => item.toLowerCase())));
-  return deduped.map((item) => item.replace(/\s+/g, ' '));
+  const byLowerCased = new Map();
+  for (const item of cleaned) {
+    const key = item.toLowerCase();
+    if (!byLowerCased.has(key)) {
+      byLowerCased.set(key, item);
+    }
+  }
+
+  return Array.from(byLowerCased.values()).map((item) => item.replace(/\s+/g, ' '));
 }
 
 function craftAgentOutputs(playbook, attachments) {

--- a/frontend/tests/idea-generator.test.js
+++ b/frontend/tests/idea-generator.test.js
@@ -29,3 +29,14 @@ test('craftPlanForDevice wires agent contributions', () => {
   assert.ok(plan.agents.security.threatModel.watchpoints.some((item) => item.includes('Attachment')));
   assert.ok(Array.isArray(plan.attachments));
 });
+
+test('craftPlanForDevice retains attachment casing while deduping', () => {
+  const plan = craftPlanForDevice('Mechanical Fan', [
+    'Quick Start Guide',
+    'quick start guide',
+    'QUICK START GUIDE',
+    'Maintenance LOG'
+  ]);
+
+  assert.deepEqual(plan.attachments, ['Quick Start Guide', 'Maintenance LOG']);
+});


### PR DESCRIPTION
## Summary
- update attachment preparation to deduplicate using lowercase keys while keeping the first occurrence's casing
- add a regression test ensuring mixed-case attachment inputs retain the original casing order in plan output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d156cd53708326b5053f0647f17ae5